### PR TITLE
allows multiple uses of sync in a row

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,8 +21,8 @@ module.exports = (gulp)->
                 task = [task]
 
             do (taskName, deps, task)->
-                check = task.concat()
                 gulp.task taskName, deps, (cb)->
+                    check = task.concat()
                     gulp.addListener 'task_stop', onStop = (e)->
                         if -1 != i = check.indexOf e.task
                             check.splice i, 1


### PR DESCRIPTION
When you use a .sync() in a watch task for example, the tasks are ran only the fist time because check variable is empty after the first run.
